### PR TITLE
feat(mltvrs): `mltvrs::interval`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,15 +3,35 @@ Language:        Cpp
 # BasedOnStyle:  LLVM
 AccessModifierOffset: -4
 AlignAfterOpenBracket: AlwaysBreak
-AlignConsecutiveMacros: true
-AlignConsecutiveAssignments: true
-AlignConsecutiveBitFields: true
-AlignConsecutiveDeclarations: true
+AlignArrayOfStructures: Left
+AlignConsecutiveAssignments:
+  Enabled:         true
+  AcrossEmptyLines: false
+  AcrossComments:  true
+  AlignCompound:   true
+  PadOperators:    true
+AlignConsecutiveBitFields:
+  Enabled:         true
+  AcrossEmptyLines: false
+  AcrossComments:  true
+  AlignCompound:   true
+  PadOperators:    true
+AlignConsecutiveDeclarations:
+  Enabled:         true
+  AcrossEmptyLines: false
+  AcrossComments:  true
+  AlignCompound:   true
+  PadOperators:    true
+AlignConsecutiveMacros:
+  Enabled:         true
+  AcrossEmptyLines: false
+  AcrossComments:  true
+  AlignCompound:   true
+  PadOperators:    true
 AlignEscapedNewlines: Right
-AlignOperands:   Align
+AlignOperands:   AlignAfterOperator
 AlignTrailingComments: true
 AllowAllArgumentsOnNextLine: false
-AllowAllConstructorInitializersOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortEnumsOnASingleLine: false
 AllowShortBlocksOnASingleLine: Never
@@ -30,26 +50,26 @@ BinPackArguments: false
 BinPackParameters: false
 BraceWrapping:
   AfterCaseLabel:  false
-  AfterClass:      false
-  AfterControlStatement: Never
+  AfterClass:      true
+  AfterControlStatement: MultiLine
   AfterEnum:       false
-  AfterFunction:   false
+  AfterFunction:   true
   AfterNamespace:  false
   AfterObjCDeclaration: false
-  AfterStruct:     false
-  AfterUnion:      false
+  AfterStruct:     true
+  AfterUnion:      true
   AfterExternBlock: false
   BeforeCatch:     false
   BeforeElse:      false
-  BeforeLambdaBody: false
+  BeforeLambdaBody: true
   BeforeWhile:     false
   IndentBraces:    false
-  SplitEmptyFunction: false
-  SplitEmptyRecord: false
-  SplitEmptyNamespace: false
-BreakBeforeBinaryOperators: None
-BreakBeforeConceptDeclarations: true
-BreakBeforeBraces: Stroustrup
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Custom
 BreakBeforeInheritanceComma: false
 BreakInheritanceList: BeforeColon
 BreakBeforeTernaryOperators: true
@@ -59,65 +79,106 @@ BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
 ColumnLimit:     100
 CommentPragmas:  '(^ IWYU pragma:)|(NOLINT)|(NOLINTNEXTLINE)'
+QualifierAlignment: Custom
+QualifierOrder:
+  - 'static'
+  - 'inline'
+  - 'constexpr'
+  - 'const'
+  - 'volatile'
+  - 'type'
 CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
 DeriveLineEnding: true
 DerivePointerAlignment: false
 DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
 ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: BinPack
+BasedOnStyle:    ''
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+AllowAllConstructorInitializersOnNextLine: false
 FixNamespaceComments: true
 ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
 IncludeBlocks:   Regroup
 IncludeCategories:
-  - Regex:           '^[<"](catch2|gtest|gmock)/.*\.((h)|(hpp))'
+  - Regex:           '^[<"]c(assert|ctype|errno|fenv|float|inttypes|limits|locale|math|setjmp|signal|stdarg|stddef|stdint|stdio|stdlib|string|time|uchar|wchar|wctype|stdatomic|iso646|stdalign|stdbool)'
     Priority:        1
-    SortPriority:    8
-    CaseSensitive:   false
-  - Regex:           '^[<"]mltvrs/[a-zA-Z0-9_]+/[a-zA-Z0-9_]+/[a-zA-Z0-9_]+/.*\.hpp'
+    SortPriority:    1
+    CaseSensitive:   true
+  - Regex:           '^[<"](catch2|gtest|gmock)/.*\.((h)|(hpp))'
     Priority:        2
-    SortPriority:    5
-  - Regex:           '^[<"]mltvrs/[a-zA-Z0-9_]+/[a-zA-Z0-9_]+/.*\.hpp'
+    SortPriority:    13
+    CaseSensitive:   true
+  - Regex:           '^[<"]gsl/.*'
     Priority:        3
-    SortPriority:    4
-  - Regex:           '^[<"]mltvrs/[a-zA-Z0-9_]+/.*\.hpp'
-    Priority:        4
     SortPriority:    3
-  - Regex:           '^[<"]mltvrs/.*\.hpp'
+    CaseSensitive:   true
+  - Regex:           '^[<"]boost/.*\.hpp'
+    Priority:        4
+    SortPriority:    4
+    CaseSensitive:   true
+  - Regex:           '^[<"]fmt/.*'
     Priority:        5
-    SortPriority:    2
-    CaseSensitive:   false
-  - Regex:           '^<.*\.((h)|(hpp))'
+    SortPriority:    5
+    CaseSensitive:   true
+  - Regex:           '^[<"]cpprest/.*'
     Priority:        6
     SortPriority:    6
-    CaseSensitive:   false
-  - Regex:           '^<.*'
+    CaseSensitive:   true
+  - Regex:           '^[<"]mltvrs/[a-zA-Z0-9_]+/[a-zA-Z0-9_]+/[a-zA-Z0-9_]+/.*\.hpp'
     Priority:        7
-    SortPriority:    1
-    CaseSensitive:   false
-  - Regex:           '.*'
+    SortPriority:    10
+    CaseSensitive:   true
+  - Regex:           '^[<"]mltvrs/[a-zA-Z0-9_]+/[a-zA-Z0-9_]+/.*\.hpp'
     Priority:        8
+    SortPriority:    9
+    CaseSensitive:   true
+  - Regex:           '^[<"]mltvrs/[a-zA-Z0-9_]+/.*\.hpp'
+    Priority:        9
+    SortPriority:    8
+    CaseSensitive:   true
+  - Regex:           '^[<"]mltvrs/.*\.hpp'
+    Priority:        10
     SortPriority:    7
-    CaseSensitive:   false
+    CaseSensitive:   true
+  - Regex:           '^<.*\.((h)|(hpp))'
+    Priority:        11
+    SortPriority:    11
+    CaseSensitive:   true
+  - Regex:           '^<.*'
+    Priority:        12
+    SortPriority:    2
+    CaseSensitive:   true
+  - Regex:           '.*'
+    Priority:        13
+    SortPriority:    12
+    CaseSensitive:   true
 IncludeIsMainRegex: '(Test)?$'
 IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: true
 IndentCaseLabels: true
 IndentCaseBlocks: true
 IndentGotoLabels: true
 IndentPPDirectives: None
 IndentExternBlock: AfterExternBlock
-IndentRequires:  true
+IndentRequiresClause: true
 IndentWidth:     4
 IndentWrappedFunctionNames: false
+InsertBraces:    true
 InsertTrailingCommas: None
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: false
+LambdaBodyIndentation: Signature
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
@@ -131,14 +192,21 @@ PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
 PenaltyBreakString: 1000
 PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PenaltyIndentedWhitespace: 0
 PointerAlignment: Left
+PPIndentWidth:   -1
+ReferenceAlignment: Pointer
 ReflowComments:  true
-SortIncludes:    true
+RemoveBracesLLVM: false
+RequiresClausePosition: OwnLine
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 0
+SortIncludes:    CaseSensitive
 SortJavaStaticImport: Before
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
@@ -150,20 +218,35 @@ SpaceBeforeCpp11BracedList: false
 SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: Never
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
 SpaceAroundPointerQualifiers: Default
 SpaceBeforeRangeBasedForLoopColon: false
 SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
-SpacesInAngles:  false
+SpacesInAngles:  Never
 SpacesInConditionalStatement: false
 SpacesInContainerLiterals: false
 SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         1
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 SpaceBeforeSquareBrackets: false
 BitFieldColonSpacing: Both
 Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
 StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,4 +4,10 @@ HeaderFilterRegex: 'mltvrs/((.*\.hpp)|(ipp/.*\.ipp))$'
 CheckOptions:
   - key  : misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
     value: '1'
+  - key  : readability-uppercase-literal-suffix.NewSuffixes
+    value: 
+      - L
+      - LL
+      - uL
+      - uLL
 ...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,13 +19,26 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 mltvrs_configure_project(PREFIX MLTVRS REPORT_ALL TRUE)
 
+#####################
+# Find Dependencies #
+#####################
+
+find_package(Microsoft.GSL REQUIRED)
+
 ##################
 # Create Targets #
 ##################
 
-set(MLTVRS_HPP ${CMAKE_CURRENT_LIST_DIR}/mltvrs/multiverse.hpp)
-set(MLTVRS_IPP )
-set(MLTVRS_CPP )
+set(
+    MLTVRS_HPP
+        ${CMAKE_CURRENT_LIST_DIR}/mltvrs/interval.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/mltvrs/multiverse.hpp
+)
+set(
+    MLTVRS_IPP
+        ${CMAKE_CURRENT_LIST_DIR}/mltvrs/ipp/interval.ipp
+)
+set(MLTVRS_CPP)
 
 add_library(mltvrs INTERFACE ${MLTVRS_HPP} ${MLTVRS_IPP} ${MLTVRS_CPP})
 target_include_directories(
@@ -34,6 +47,7 @@ target_include_directories(
             $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
             $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/mltvrs>
 )
+target_link_libraries(mltvrs INTERFACE Microsoft.GSL::GSL)
 add_library(mltvrs::mltvrs ALIAS mltvrs)
 
 #########################

--- a/cmake/project-config.cmake
+++ b/cmake/project-config.cmake
@@ -201,7 +201,7 @@ function(mltvrs_configure_project)
         )
     endif()
     if(EXISTS ${CMAKE_SOURCE_DIR}/conan/conan.lock)
-        list(PREPEND CMAKE_PREFIX_PATH ${CMAKE_SOURCE_DIR}/conan)
+        list(PREPEND CMAKE_PREFIX_PATH ${CMAKE_SOURCE_DIR}/build/${CMAKE_BUILD_TYPE}/generators)
     endif()
     mltvrs_report_option(ENABLE_CONAN_OVERRIDE)
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -38,6 +38,7 @@ class MultiverseConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
+        tc.cache_variables["CMAKE_CXX_STANDARD"] = 20
         tc.generate()
 
     def build(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,8 +5,8 @@ from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
 class MultiverseConan(ConanFile):
     name = "multiverse"
     version = "0.0.1"
-    requires = "boost/1.81.0", "fmt/5.3.0", "catch2/2.13.9", "ms-gsl/4.0.0"
-    generators = "cmake_find_package_multi"
+    requires = "boost/1.81.0", "fmt/5.3.0", "ms-gsl/4.0.0"
+    generators = "CMakeDeps"
 
     # Optional metadata
     license = "MIT"

--- a/mltvrs/interval.hpp
+++ b/mltvrs/interval.hpp
@@ -13,6 +13,11 @@ namespace mltvrs {
     struct end_point
     {
         public:
+            using ordering = std::conditional_t<
+                std::three_way_comparable<T, std::weak_ordering>,
+                std::weak_ordering,
+                std::partial_ordering>;
+
             constexpr end_point() = default;
             constexpr end_point(T val) noexcept : value{val} {}
             constexpr end_point(T val, end_type endt) noexcept : value{val}, type{endt} {}
@@ -23,19 +28,9 @@ namespace mltvrs {
             [[nodiscard]] friend constexpr bool
             operator==(const end_point& lhs, const end_point& rhs) noexcept = default;
             [[nodiscard]] friend constexpr auto
-            operator<=>(const end_point& lhs, const end_point& rhs) noexcept -> std::weak_ordering
+            operator<=>(const end_point& lhs, const end_point& rhs) noexcept -> ordering
             {
                 return lhs.value <=> rhs.value;
-            }
-
-            [[nodiscard]] friend constexpr bool operator==(T lhs, end_point rhs) noexcept
-            {
-                return (rhs.type == end_type::closed) && (lhs == rhs.value);
-            }
-            [[nodiscard]] friend constexpr auto operator<=>(T lhs, end_point rhs) noexcept
-                -> std::weak_ordering
-            {
-                return lhs <=> rhs.value;
             }
     };
 
@@ -43,32 +38,22 @@ namespace mltvrs {
     struct interval
     {
         public:
-            using ordering = std::conditional_t<
-                std::three_way_comparable<T, std::weak_ordering>,
-                std::weak_ordering,
-                std::partial_ordering>;
-            using end_point = mltvrs::end_point<T>;
+            using end_point = mltvrs::end_point<T>; //!< The type of the interval endpoints.
 
             end_point max;
             end_point min;
 
             [[nodiscard]] friend constexpr bool
             operator==(const interval& lhs, const interval& rhs) noexcept = default;
-            [[nodiscard]] friend constexpr auto
-            operator<=>(const interval& lhs, const interval& rhs) noexcept -> std::partial_ordering
-            {
-                return cmp(lhs, rhs);
-            }
 
             [[nodiscard]] friend constexpr auto operator<=>(T lhs, interval rhs) noexcept
-                -> ordering
+                -> std::partial_ordering
             {
                 return cmp(lhs, rhs);
             }
 
         private:
-            [[nodiscard]] static constexpr auto cmp(T lhs, interval rhs) noexcept -> ordering;
-            [[nodiscard]] static constexpr auto cmp(interval lhs, interval rhs) noexcept
+            [[nodiscard]] static constexpr auto cmp(T lhs, interval rhs) noexcept
                 -> std::partial_ordering;
     };
 

--- a/mltvrs/interval.hpp
+++ b/mltvrs/interval.hpp
@@ -33,6 +33,7 @@ namespace mltvrs {
                 return (rhs.type == end_type::closed) && (lhs == rhs.value);
             }
             [[nodiscard]] friend constexpr auto operator<=>(T lhs, end_point rhs) noexcept
+                -> std::weak_ordering
             {
                 return lhs <=> rhs.value;
             }

--- a/mltvrs/interval.hpp
+++ b/mltvrs/interval.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <compare>
+
+namespace mltvrs {
+
+    enum class end_type {
+        open,
+        closed
+    };
+
+    template<typename T>
+    struct end_point
+    {
+        public:
+            constexpr end_point() = default;
+            constexpr end_point(T val) noexcept : value{val} {}
+            constexpr end_point(T val, end_type endt) noexcept : value{val}, type{endt} {}
+
+            T        value;
+            end_type type = end_type::closed;
+
+            [[nodiscard]] friend constexpr bool
+            operator==(const end_point& lhs, const end_point& rhs) noexcept = default;
+            [[nodiscard]] friend constexpr auto
+            operator<=>(const end_point& lhs, const end_point& rhs) noexcept -> std::weak_ordering
+            {
+                return lhs.value <=> rhs.value;
+            }
+
+            [[nodiscard]] friend constexpr bool operator==(T lhs, end_point rhs) noexcept
+            {
+                return (rhs.type == end_type::closed) && (lhs == rhs.value);
+            }
+            [[nodiscard]] friend constexpr auto operator<=>(T lhs, end_point rhs) noexcept
+            {
+                return lhs <=> rhs.value;
+            }
+    };
+
+    template<typename T>
+    struct interval
+    {
+        public:
+            using ordering = std::conditional_t<
+                std::three_way_comparable<T, std::weak_ordering>,
+                std::weak_ordering,
+                std::partial_ordering>;
+            using end_point = mltvrs::end_point<T>;
+
+            end_point max;
+            end_point min;
+
+            [[nodiscard]] friend constexpr bool
+            operator==(const interval& lhs, const interval& rhs) noexcept = default;
+            [[nodiscard]] friend constexpr auto
+            operator<=>(const interval& lhs, const interval& rhs) noexcept -> std::partial_ordering
+            {
+                return cmp(lhs, rhs);
+            }
+
+            [[nodiscard]] friend constexpr auto operator<=>(T lhs, interval rhs) noexcept
+                -> ordering
+            {
+                return cmp(lhs, rhs);
+            }
+
+        private:
+            [[nodiscard]] static constexpr auto cmp(T lhs, interval rhs) noexcept -> ordering;
+            [[nodiscard]] static constexpr auto cmp(interval lhs, interval rhs) noexcept
+                -> std::partial_ordering;
+    };
+
+} // namespace mltvrs
+
+#include <mltvrs/ipp/interval.ipp>

--- a/mltvrs/interval.hpp
+++ b/mltvrs/interval.hpp
@@ -4,27 +4,72 @@
 
 namespace mltvrs {
 
+    /**
+     * @brief Types of mathematical interval endpoints.
+     */
     enum class end_type {
-        open,
-        closed
+        open,  //!< Open interval ending.
+        closed //!< Closed interval ending.
     };
 
+    /**
+     * @brief An endpoint of a numeric interval.
+     *
+     * @tparam T The underlying numeric type.
+     */
     template<typename T>
     struct end_point
     {
         public:
+            //! The endpoint ordering type.
             using ordering = std::conditional_t<
                 std::three_way_comparable<T, std::weak_ordering>,
                 std::weak_ordering,
                 std::partial_ordering>;
 
+            /**
+             * @name Constructors
+             *
+             * @brief Construct an endpoint at the given value.
+             *
+             * @param val  The endpoint value.
+             * @param endt The endpoint type.
+             *
+             * @{
+             */
             constexpr end_point() = default;
             constexpr end_point(T val) noexcept : value{val} {}
             constexpr end_point(T val, end_type endt) noexcept : value{val}, type{endt} {}
+            //! @}
 
-            T        value;
-            end_type type = end_type::closed;
+            T        value;                   //!< The value the endpoint resides at.
+            end_type type = end_type::closed; //!< The type of interval endpoint.
 
+            /**
+             * @name Comparison
+             *
+             * @brief Compare two endpoints against each other.
+             *
+             * Endpoints have, at most, weak ordering by value. Endpoints compare equal if they
+             * reside at the same numeric value, and also have the same endpoint type. Endpoints at
+             * the same numeric value, but with different endpoint types, are equivalent but not
+             * equal.
+             *
+             * Endpoint ordering can only be as strong as the underlying numeric type's ordering. If
+             * two endpoints' numeric values are unordered with respect to each other, the endpoints
+             * are also not ordered.
+             *
+             * Comparison against values of the underlying numeric type is supported via implicit
+             * conversion from that type. Values of the underlying numeric type are considered
+             * closed endpoints.
+             *
+             * @param lhs The left-hand-side endpoint to compare.
+             * @param rhs The right-hand-side endpoint to compare.
+             *
+             * @return Returns the comparison result.
+             *
+             * @{
+             */
             [[nodiscard]] friend constexpr bool
             operator==(const end_point& lhs, const end_point& rhs) noexcept = default;
             [[nodiscard]] friend constexpr auto
@@ -32,20 +77,52 @@ namespace mltvrs {
             {
                 return lhs.value <=> rhs.value;
             }
+            //! @}
     };
 
+    /**
+     * @brief A numeric interval.
+     *
+     * The underlying numeric type must posess at least weak ordering.
+     *
+     * @tparam T The underlying numeric type.
+     */
     template<typename T>
     struct interval
     {
         public:
             using end_point = mltvrs::end_point<T>; //!< The type of the interval endpoints.
 
-            end_point max;
-            end_point min;
+            end_point max;                          //!< The high endpoint.
+            end_point min;                          //!< The low endpoint.
 
+            /**
+             * @brief Check whether two intervals are exactly equal or not.
+             *
+             * Intervals only equal each other if their endpoints are exactly equal, meaning they
+             * are at the same values, and have the same endpoint types.
+             *
+             * @param lhs The left-hand-side interval to compare.
+             * @param rhs The right-hand-side interval to compare.
+             *
+             * @return Returns the comparison result.
+             */
             [[nodiscard]] friend constexpr bool
             operator==(const interval& lhs, const interval& rhs) noexcept = default;
 
+            /**
+             * @brief Check whether a value is above or below an interval.
+             *
+             * A numeric value is partially ordered with respect to an interval. If the value is
+             * above the interval, it compares greater than the interval. If the value is below the
+             * interval, it compares less than the interval. If the value is part of the interval,
+             * it is unordered with respect to the interval.
+             *
+             * @param lhs The numeric value to check against the interval.
+             * @param rhs The interval to check the numeric value against.
+             *
+             * @return Returns the comparison result.
+             */
             [[nodiscard]] friend constexpr auto operator<=>(T lhs, interval rhs) noexcept
                 -> std::partial_ordering
             {

--- a/mltvrs/ipp/interval.ipp
+++ b/mltvrs/ipp/interval.ipp
@@ -1,0 +1,40 @@
+#include <gsl/gsl>
+
+template<typename T>
+[[nodiscard]] constexpr auto mltvrs::interval<T>::cmp(T lhs, interval rhs) noexcept -> ordering
+{
+    Expects(rhs.max >= rhs.min);
+
+    if((lhs > rhs.max) && (lhs > rhs.min)) {
+        return ordering::greater;
+    }
+    if((lhs < rhs.max) && (lhs < rhs.min)) {
+        return ordering::less;
+    }
+    if constexpr(std::same_as<ordering, std::partial_ordering>) {
+        return ((lhs <= rhs.max) && (lhs >= rhs.min)) ? ordering::equivalent
+                                                      : std::partial_ordering::unordered;
+    } else {
+        return ordering::equivalent;
+    }
+}
+
+template<typename T>
+[[nodiscard]] constexpr auto mltvrs::interval<T>::cmp(interval lhs, interval rhs) noexcept
+    -> std::partial_ordering
+{
+    Expects(lhs.max >= lhs.min);
+    Expects(rhs.max >= rhs.min);
+
+    if(lhs == rhs) {
+        return std::partial_ordering::equivalent;
+    }
+    if((lhs.max <= rhs.max) && (lhs.min < rhs.min)) {
+        return std::partial_ordering::less;
+    }
+    if((lhs.max > rhs.max) && (lhs.min >= rhs.min)) {
+        return std::partial_ordering::greater;
+    }
+
+    return std::partial_ordering::unordered;
+}

--- a/mltvrs/ipp/interval.ipp
+++ b/mltvrs/ipp/interval.ipp
@@ -7,10 +7,10 @@ template<typename T>
     Expects(rhs.max >= rhs.min);
 
     if((lhs > rhs.max) && (lhs > rhs.min)) {
-        return ordering::greater;
+        return std::partial_ordering::greater;
     }
     if((lhs < rhs.max) && (lhs < rhs.min)) {
-        return ordering::less;
+        return std::partial_ordering::less;
     }
 
     return std::partial_ordering::unordered;

--- a/mltvrs/ipp/interval.ipp
+++ b/mltvrs/ipp/interval.ipp
@@ -1,7 +1,8 @@
 #include <gsl/gsl>
 
 template<typename T>
-[[nodiscard]] constexpr auto mltvrs::interval<T>::cmp(T lhs, interval rhs) noexcept -> ordering
+[[nodiscard]] constexpr auto mltvrs::interval<T>::cmp(T lhs, interval rhs) noexcept
+    -> std::partial_ordering
 {
     Expects(rhs.max >= rhs.min);
 
@@ -10,30 +11,6 @@ template<typename T>
     }
     if((lhs < rhs.max) && (lhs < rhs.min)) {
         return ordering::less;
-    }
-    if constexpr(std::same_as<ordering, std::partial_ordering>) {
-        return ((lhs <= rhs.max) && (lhs >= rhs.min)) ? ordering::equivalent
-                                                      : std::partial_ordering::unordered;
-    } else {
-        return ordering::equivalent;
-    }
-}
-
-template<typename T>
-[[nodiscard]] constexpr auto mltvrs::interval<T>::cmp(interval lhs, interval rhs) noexcept
-    -> std::partial_ordering
-{
-    Expects(lhs.max >= lhs.min);
-    Expects(rhs.max >= rhs.min);
-
-    if(lhs == rhs) {
-        return std::partial_ordering::equivalent;
-    }
-    if((lhs.max <= rhs.max) && (lhs.min < rhs.min)) {
-        return std::partial_ordering::less;
-    }
-    if((lhs.max > rhs.max) && (lhs.min >= rhs.min)) {
-        return std::partial_ordering::greater;
     }
 
     return std::partial_ordering::unordered;


### PR DESCRIPTION
Introduce `mltvrs::interval`, representing an interval between two points in an at-least-partially-ordered set.