### PR TITLE
feat(mltvrs): `mltvrs::basic_string_literal`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,15 +3,35 @@ Language:        Cpp
 # BasedOnStyle:  LLVM
 AccessModifierOffset: -4
 AlignAfterOpenBracket: AlwaysBreak
-AlignConsecutiveMacros: true
-AlignConsecutiveAssignments: true
-AlignConsecutiveBitFields: true
-AlignConsecutiveDeclarations: true
+AlignArrayOfStructures: Right
+AlignConsecutiveAssignments:
+  Enabled:         true
+  AcrossEmptyLines: false
+  AcrossComments:  true
+  AlignCompound:   true
+  PadOperators:    true
+AlignConsecutiveBitFields:
+  Enabled:         true
+  AcrossEmptyLines: false
+  AcrossComments:  true
+  AlignCompound:   true
+  PadOperators:    true
+AlignConsecutiveDeclarations:
+  Enabled:         true
+  AcrossEmptyLines: false
+  AcrossComments:  true
+  AlignCompound:   true
+  PadOperators:    true
+AlignConsecutiveMacros:
+  Enabled:         true
+  AcrossEmptyLines: false
+  AcrossComments:  true
+  AlignCompound:   true
+  PadOperators:    true
 AlignEscapedNewlines: Right
 AlignOperands:   Align
 AlignTrailingComments: true
 AllowAllArgumentsOnNextLine: false
-AllowAllConstructorInitializersOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortEnumsOnASingleLine: false
 AllowShortBlocksOnASingleLine: Never
@@ -30,26 +50,26 @@ BinPackArguments: false
 BinPackParameters: false
 BraceWrapping:
   AfterCaseLabel:  false
-  AfterClass:      false
-  AfterControlStatement: Never
+  AfterClass:      true
+  AfterControlStatement: MultiLine
   AfterEnum:       false
   AfterFunction:   false
   AfterNamespace:  false
   AfterObjCDeclaration: false
-  AfterStruct:     false
-  AfterUnion:      false
+  AfterStruct:     true
+  AfterUnion:      true
   AfterExternBlock: false
   BeforeCatch:     false
   BeforeElse:      false
-  BeforeLambdaBody: false
+  BeforeLambdaBody: true
   BeforeWhile:     false
   IndentBraces:    false
-  SplitEmptyFunction: false
-  SplitEmptyRecord: false
-  SplitEmptyNamespace: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
 BreakBeforeBinaryOperators: None
-BreakBeforeConceptDeclarations: true
-BreakBeforeBraces: Stroustrup
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Custom
 BreakBeforeInheritanceComma: false
 BreakInheritanceList: BeforeColon
 BreakBeforeTernaryOperators: true
@@ -59,20 +79,35 @@ BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
 ColumnLimit:     100
 CommentPragmas:  '(^ IWYU pragma:)|(NOLINT)|(NOLINTNEXTLINE)'
+QualifierAlignment: Custom
+QualifierOrder:
+  - 'static'
+  - 'inline'
+  - 'constexpr'
+  - 'const'
+  - 'volatile'
+  - 'type'
 CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
 DeriveLineEnding: true
 DerivePointerAlignment: false
 DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
 ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: BinPack
+BasedOnStyle:    ''
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+AllowAllConstructorInitializersOnNextLine: false
 FixNamespaceComments: true
 ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
 IncludeBlocks:   Regroup
 IncludeCategories:
   - Regex:           '^[<"](catch2|gtest|gmock)/.*\.((h)|(hpp))'
@@ -106,18 +141,21 @@ IncludeCategories:
     CaseSensitive:   false
 IncludeIsMainRegex: '(Test)?$'
 IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: true
 IndentCaseLabels: true
 IndentCaseBlocks: true
 IndentGotoLabels: true
 IndentPPDirectives: None
 IndentExternBlock: AfterExternBlock
-IndentRequires:  true
+IndentRequiresClause: true
 IndentWidth:     4
 IndentWrappedFunctionNames: false
+InsertBraces:    true
 InsertTrailingCommas: None
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: false
+LambdaBodyIndentation: Signature
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
@@ -131,14 +169,21 @@ PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
 PenaltyBreakString: 1000
 PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PenaltyIndentedWhitespace: 0
 PointerAlignment: Left
+PPIndentWidth:   -1
+ReferenceAlignment: Pointer
 ReflowComments:  true
-SortIncludes:    true
+RemoveBracesLLVM: false
+RequiresClausePosition: OwnLine
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 0
+SortIncludes:    CaseSensitive
 SortJavaStaticImport: Before
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
@@ -150,20 +195,35 @@ SpaceBeforeCpp11BracedList: false
 SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: Never
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
 SpaceAroundPointerQualifiers: Default
 SpaceBeforeRangeBasedForLoopColon: false
 SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
-SpacesInAngles:  false
+SpacesInAngles:  Never
 SpacesInConditionalStatement: false
 SpacesInContainerLiterals: false
 SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         1
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 SpaceBeforeSquareBrackets: false
 BitFieldColonSpacing: Both
 Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
 StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION

--- a/.clang-format
+++ b/.clang-format
@@ -53,7 +53,7 @@ BraceWrapping:
   AfterClass:      true
   AfterControlStatement: MultiLine
   AfterEnum:       false
-  AfterFunction:   false
+  AfterFunction:   true
   AfterNamespace:  false
   AfterObjCDeclaration: false
   AfterStruct:     true

--- a/.clang-format
+++ b/.clang-format
@@ -116,42 +116,51 @@ IncludeCategories:
     CaseSensitive:   true
   - Regex:           '^[<"](catch2|gtest|gmock)/.*\.((h)|(hpp))'
     Priority:        2
-    SortPriority:    9
+    SortPriority:    13
     CaseSensitive:   true
   - Regex:           '^[<"]gsl/.*'
     Priority:        3
     SortPriority:    3
+    CaseSensitive:   true
   - Regex:           '^[<"]boost/.*\.hpp'
     Priority:        4
     SortPriority:    4
     CaseSensitive:   true
-  - Regex:           '^[<"]mltvrs/[a-zA-Z0-9_]+/[a-zA-Z0-9_]+/[a-zA-Z0-9_]+/.*\.hpp'
+  - Regex:           '^[<"]fmt/.*'
     Priority:        5
-    SortPriority:    8
-    CaseSensitive:   true
-  - Regex:           '^[<"]mltvrs/[a-zA-Z0-9_]+/[a-zA-Z0-9_]+/.*\.hpp'
-    Priority:        6
-    SortPriority:    7
-    CaseSensitive:   true
-  - Regex:           '^[<"]mltvrs/[a-zA-Z0-9_]+/.*\.hpp'
-    Priority:        7
-    SortPriority:    6
-    CaseSensitive:   true
-  - Regex:           '^[<"]mltvrs/.*\.hpp'
-    Priority:        8
     SortPriority:    5
     CaseSensitive:   true
-  - Regex:           '^<.*\.((h)|(hpp))'
-    Priority:        9
+  - Regex:           '^[<"]cpprest/.*'
+    Priority:        6
+    SortPriority:    6
+    CaseSensitive:   true
+  - Regex:           '^[<"]mltvrs/[a-zA-Z0-9_]+/[a-zA-Z0-9_]+/[a-zA-Z0-9_]+/.*\.hpp'
+    Priority:        7
     SortPriority:    10
     CaseSensitive:   true
-  - Regex:           '^<.*'
+  - Regex:           '^[<"]mltvrs/[a-zA-Z0-9_]+/[a-zA-Z0-9_]+/.*\.hpp'
+    Priority:        8
+    SortPriority:    9
+    CaseSensitive:   true
+  - Regex:           '^[<"]mltvrs/[a-zA-Z0-9_]+/.*\.hpp'
+    Priority:        9
+    SortPriority:    8
+    CaseSensitive:   true
+  - Regex:           '^[<"]mltvrs/.*\.hpp'
     Priority:        10
+    SortPriority:    7
+    CaseSensitive:   true
+  - Regex:           '^<.*\.((h)|(hpp))'
+    Priority:        11
+    SortPriority:    11
+    CaseSensitive:   true
+  - Regex:           '^<.*'
+    Priority:        12
     SortPriority:    2
     CaseSensitive:   true
   - Regex:           '.*'
-    Priority:        11
-    SortPriority:    11
+    Priority:        13
+    SortPriority:    12
     CaseSensitive:   true
 IncludeIsMainRegex: '(Test)?$'
 IncludeIsMainSourceRegex: ''

--- a/.clang-format
+++ b/.clang-format
@@ -3,7 +3,7 @@ Language:        Cpp
 # BasedOnStyle:  LLVM
 AccessModifierOffset: -4
 AlignAfterOpenBracket: AlwaysBreak
-AlignArrayOfStructures: Right
+AlignArrayOfStructures: Left
 AlignConsecutiveAssignments:
   Enabled:         true
   AcrossEmptyLines: false

--- a/.clang-format
+++ b/.clang-format
@@ -110,44 +110,48 @@ IfMacros:
   - KJ_IF_MAYBE
 IncludeBlocks:   Regroup
 IncludeCategories:
-  - Regex:           '^[<"](catch2|gtest|gmock)/.*\.((h)|(hpp))'
+  - Regex:           '^[<"]c(assert|ctype|errno|fenv|float|inttypes|limits|locale|math|setjmp|signal|stdarg|stddef|stdint|stdio|stdlib|string|time|uchar|wchar|wctype|stdatomic|iso646|stdalign|stdbool)'
     Priority:        1
-    SortPriority:    8
-    CaseSensitive:   true
-  - Regex:           '^[<"]gsl/.*'
-    Priority:        2
-    SortPriority:    2
-  - Regex:           '^[<"]boost/.*\.hpp'
-    Priority:        3
-    SortPriority:    3
-    CaseSensitive:   true
-  - Regex:           '^[<"]mltvrs/[a-zA-Z0-9_]+/[a-zA-Z0-9_]+/[a-zA-Z0-9_]+/.*\.hpp'
-    Priority:        4
-    SortPriority:    7
-    CaseSensitive:   true
-  - Regex:           '^[<"]mltvrs/[a-zA-Z0-9_]+/[a-zA-Z0-9_]+/.*\.hpp'
-    Priority:        5
-    SortPriority:    6
-    CaseSensitive:   true
-  - Regex:           '^[<"]mltvrs/[a-zA-Z0-9_]+/.*\.hpp'
-    Priority:        6
-    SortPriority:    5
-    CaseSensitive:   true
-  - Regex:           '^[<"]mltvrs/.*\.hpp'
-    Priority:        7
-    SortPriority:    4
-    CaseSensitive:   true
-  - Regex:           '^<.*\.((h)|(hpp))'
-    Priority:        8
-    SortPriority:    9
-    CaseSensitive:   true
-  - Regex:           '^<.*'
-    Priority:        9
     SortPriority:    1
     CaseSensitive:   true
-  - Regex:           '.*'
-    Priority:        10
+  - Regex:           '^[<"](catch2|gtest|gmock)/.*\.((h)|(hpp))'
+    Priority:        2
+    SortPriority:    9
+    CaseSensitive:   true
+  - Regex:           '^[<"]gsl/.*'
+    Priority:        3
+    SortPriority:    3
+  - Regex:           '^[<"]boost/.*\.hpp'
+    Priority:        4
+    SortPriority:    4
+    CaseSensitive:   true
+  - Regex:           '^[<"]mltvrs/[a-zA-Z0-9_]+/[a-zA-Z0-9_]+/[a-zA-Z0-9_]+/.*\.hpp'
+    Priority:        5
+    SortPriority:    8
+    CaseSensitive:   true
+  - Regex:           '^[<"]mltvrs/[a-zA-Z0-9_]+/[a-zA-Z0-9_]+/.*\.hpp'
+    Priority:        6
+    SortPriority:    7
+    CaseSensitive:   true
+  - Regex:           '^[<"]mltvrs/[a-zA-Z0-9_]+/.*\.hpp'
+    Priority:        7
+    SortPriority:    6
+    CaseSensitive:   true
+  - Regex:           '^[<"]mltvrs/.*\.hpp'
+    Priority:        8
+    SortPriority:    5
+    CaseSensitive:   true
+  - Regex:           '^<.*\.((h)|(hpp))'
+    Priority:        9
     SortPriority:    10
+    CaseSensitive:   true
+  - Regex:           '^<.*'
+    Priority:        10
+    SortPriority:    2
+    CaseSensitive:   true
+  - Regex:           '.*'
+    Priority:        11
+    SortPriority:    11
     CaseSensitive:   true
 IncludeIsMainRegex: '(Test)?$'
 IncludeIsMainSourceRegex: ''

--- a/.clang-format
+++ b/.clang-format
@@ -29,7 +29,7 @@ AlignConsecutiveMacros:
   AlignCompound:   true
   PadOperators:    true
 AlignEscapedNewlines: Right
-AlignOperands:   Align
+AlignOperands:   AlignAfterOperator
 AlignTrailingComments: true
 AllowAllArgumentsOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: false
@@ -67,7 +67,7 @@ BraceWrapping:
   SplitEmptyFunction: true
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
-BreakBeforeBinaryOperators: None
+BreakBeforeBinaryOperators: NonAssignment
 BreakBeforeConceptDeclarations: Always
 BreakBeforeBraces: Custom
 BreakBeforeInheritanceComma: false

--- a/.clang-format
+++ b/.clang-format
@@ -113,32 +113,42 @@ IncludeCategories:
   - Regex:           '^[<"](catch2|gtest|gmock)/.*\.((h)|(hpp))'
     Priority:        1
     SortPriority:    8
-    CaseSensitive:   false
-  - Regex:           '^[<"]mltvrs/[a-zA-Z0-9_]+/[a-zA-Z0-9_]+/[a-zA-Z0-9_]+/.*\.hpp'
+    CaseSensitive:   true
+  - Regex:           '^[<"]gsl/.*'
     Priority:        2
-    SortPriority:    5
-  - Regex:           '^[<"]mltvrs/[a-zA-Z0-9_]+/[a-zA-Z0-9_]+/.*\.hpp'
-    Priority:        3
-    SortPriority:    4
-  - Regex:           '^[<"]mltvrs/[a-zA-Z0-9_]+/.*\.hpp'
-    Priority:        4
-    SortPriority:    3
-  - Regex:           '^[<"]mltvrs/.*\.hpp'
-    Priority:        5
     SortPriority:    2
-    CaseSensitive:   false
-  - Regex:           '^<.*\.((h)|(hpp))'
-    Priority:        6
-    SortPriority:    6
-    CaseSensitive:   false
-  - Regex:           '^<.*'
-    Priority:        7
-    SortPriority:    1
-    CaseSensitive:   false
-  - Regex:           '.*'
-    Priority:        8
+  - Regex:           '^[<"]boost/.*\.hpp'
+    Priority:        3
+    SortPriority:    3
+    CaseSensitive:   true
+  - Regex:           '^[<"]mltvrs/[a-zA-Z0-9_]+/[a-zA-Z0-9_]+/[a-zA-Z0-9_]+/.*\.hpp'
+    Priority:        4
     SortPriority:    7
-    CaseSensitive:   false
+    CaseSensitive:   true
+  - Regex:           '^[<"]mltvrs/[a-zA-Z0-9_]+/[a-zA-Z0-9_]+/.*\.hpp'
+    Priority:        5
+    SortPriority:    6
+    CaseSensitive:   true
+  - Regex:           '^[<"]mltvrs/[a-zA-Z0-9_]+/.*\.hpp'
+    Priority:        6
+    SortPriority:    5
+    CaseSensitive:   true
+  - Regex:           '^[<"]mltvrs/.*\.hpp'
+    Priority:        7
+    SortPriority:    4
+    CaseSensitive:   true
+  - Regex:           '^<.*\.((h)|(hpp))'
+    Priority:        8
+    SortPriority:    9
+    CaseSensitive:   true
+  - Regex:           '^<.*'
+    Priority:        9
+    SortPriority:    1
+    CaseSensitive:   true
+  - Regex:           '.*'
+    Priority:        10
+    SortPriority:    10
+    CaseSensitive:   true
 IncludeIsMainRegex: '(Test)?$'
 IncludeIsMainSourceRegex: ''
 IndentAccessModifiers: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,9 +23,16 @@ mltvrs_configure_project(PREFIX MLTVRS REPORT_ALL TRUE)
 # Create Targets #
 ##################
 
-set(MLTVRS_HPP ${CMAKE_CURRENT_LIST_DIR}/mltvrs/multiverse.hpp)
-set(MLTVRS_IPP )
-set(MLTVRS_CPP )
+set(
+    MLTVRS_HPP
+        ${CMAKE_CURRENT_LIST_DIR}/mltvrs/multiverse.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/mltvrs/string_literal.hpp
+)
+set(
+    MLTVRS_IPP
+        ${CMAKE_CURRENT_LIST_DIR}/mltvrs/ipp/string_literal.ipp
+)
+set(MLTVRS_CPP)
 
 add_library(mltvrs INTERFACE ${MLTVRS_HPP} ${MLTVRS_IPP} ${MLTVRS_CPP})
 target_include_directories(

--- a/mltvrs/ipp/string_literal.ipp
+++ b/mltvrs/ipp/string_literal.ipp
@@ -1,6 +1,6 @@
 
 template<typename CharT, std::size_t N>
-constexpr mltvrs::basic_string_literal<CharT, N>::basic_string_literal(
+consteval mltvrs::basic_string_literal<CharT, N>::basic_string_literal(
     const CharT (&arr)[N + 1]) noexcept
     : basic_string_literal{arr, std::make_index_sequence<N>{}}
 {
@@ -8,7 +8,7 @@ constexpr mltvrs::basic_string_literal<CharT, N>::basic_string_literal(
 
 template<typename CharT, std::size_t N>
 template<std::size_t... I>
-constexpr mltvrs::basic_string_literal<CharT, N>::basic_string_literal(
+consteval mltvrs::basic_string_literal<CharT, N>::basic_string_literal(
     const CharT (&arr)[N + 1],
     std::index_sequence<I...> /*unused*/) noexcept
     : basic_string_literal{arr[I]...}
@@ -17,7 +17,7 @@ constexpr mltvrs::basic_string_literal<CharT, N>::basic_string_literal(
 
 template<typename CharT, std::size_t N>
 template<typename... C>
-constexpr mltvrs::basic_string_literal<CharT, N>::basic_string_literal(C... c) noexcept
+consteval mltvrs::basic_string_literal<CharT, N>::basic_string_literal(C... c) noexcept
     : value{c..., CharT{}}
 {
 }

--- a/mltvrs/ipp/string_literal.ipp
+++ b/mltvrs/ipp/string_literal.ipp
@@ -1,0 +1,44 @@
+
+template<typename CharT, std::size_t N>
+constexpr mltvrs::basic_string_literal<CharT, N>::basic_string_literal(
+    const CharT (&arr)[N + 1]) noexcept
+    : basic_string_literal{arr, std::make_index_sequence<N>{}}
+{
+}
+
+template<typename CharT, std::size_t N>
+template<std::size_t... I>
+constexpr mltvrs::basic_string_literal<CharT, N>::basic_string_literal(
+    const CharT (&arr)[N + 1],
+    std::index_sequence<I...> /*unused*/) noexcept
+    : basic_string_literal{arr[I]...}
+{
+}
+
+template<typename CharT, std::size_t N>
+template<typename... C>
+constexpr mltvrs::basic_string_literal<CharT, N>::basic_string_literal(C... c) noexcept
+    : value{c..., CharT{}}
+{
+}
+
+template<typename CharT, std::size_t N>
+[[nodiscard]] constexpr auto mltvrs::basic_string_literal<CharT, N>::cbegin() const noexcept
+    -> const_iterator
+{
+    return data();
+}
+
+template<typename CharT, std::size_t N>
+[[nodiscard]] constexpr auto mltvrs::basic_string_literal<CharT, N>::end() const noexcept
+    -> const_iterator
+{
+    return data() + N;
+}
+
+template<typename CharT, std::size_t N>
+[[nodiscard]] constexpr auto mltvrs::basic_string_literal<CharT, N>::cend() const noexcept
+    -> const_iterator
+{
+    return data() + N;
+}

--- a/mltvrs/string_literal.hpp
+++ b/mltvrs/string_literal.hpp
@@ -30,7 +30,7 @@ namespace mltvrs {
             /**
              * @brief Default-construct zero-length string literal.
              */
-            constexpr basic_string_literal() noexcept
+            consteval basic_string_literal() noexcept
                 requires(N == 0)
             = default;
 
@@ -39,7 +39,7 @@ namespace mltvrs {
              *
              * @param arr A constant character array to initialize from.
              */
-            constexpr basic_string_literal(const CharT (&arr)[N + 1]) noexcept;
+            consteval basic_string_literal(const CharT (&arr)[N + 1]) noexcept;
 
             /**
              * @name Literal Access
@@ -81,11 +81,11 @@ namespace mltvrs {
 
         private:
             template<std::size_t... I>
-            constexpr basic_string_literal(
+            consteval basic_string_literal(
                 const CharT (&arr)[N + 1],
                 std::index_sequence<I...> /*unused*/) noexcept;
             template<typename... C>
-            constexpr basic_string_literal(C... c) noexcept;
+            consteval basic_string_literal(C... c) noexcept;
     };
 
     /**

--- a/mltvrs/string_literal.hpp
+++ b/mltvrs/string_literal.hpp
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <type_traits>
+#include <utility>
+
+namespace mltvrs {
+
+    /**
+     * @brief String literal type.
+     *
+     * @tparam CharT The string character type.
+     * @tparam N     The number of characters in the string.
+     */
+    template<typename CharT, std::size_t N>
+    struct basic_string_literal
+    {
+        private:
+            using storage_type = CharT[N + 1];
+
+        public:
+            using value_type      = CharT;             //!< Character type.
+            using size_type       = std::size_t;       //!< String length type.
+            using const_reference = const value_type&; //!< Immutable character reference.
+            using reference       = const_reference;   //!< Mutable character reference.
+            using const_pointer   = const value_type*; //!< Immutable character pointer.
+            using pointer         = const_pointer;     //!< Mutable character pointer.
+            using iterator        = pointer;           //!< Mutable character iterator.
+            using const_iterator  = const_pointer;     //!< Immutable character iterator.
+
+            /**
+             * @brief Default-construct zero-length string literal.
+             */
+            constexpr basic_string_literal() noexcept
+                requires(N == 0)
+            = default;
+
+            /**
+             * @brief Construct string literal from constant character array.
+             *
+             * @param arr A constant character array to initialize from.
+             */
+            constexpr basic_string_literal(const CharT (&arr)[N + 1]) noexcept;
+
+            /**
+             * @name Literal Access
+             *
+             * @brief Access as a string literal.
+             *
+             * @return Returns the represented string literal.
+             *
+             * @{
+             */
+            [[nodiscard]] constexpr operator const storage_type&() const noexcept { return value; }
+            [[nodiscard]] constexpr auto data() const noexcept -> const_pointer { return value; }
+            [[nodiscard]] constexpr auto c_str() const noexcept -> const_pointer { return value; }
+            //! @}
+
+            /**
+             * @brief Obtain the string literal length, including the null terminator.
+             *
+             * @return Returns the string literal length.
+             */
+            [[nodiscard]] constexpr auto size() const noexcept -> size_type { return N; }
+
+            /**
+             * @name Iterators
+             *
+             * @brief Obtain iterators into the string literal.
+             *
+             * @return Returns the requested iterator.
+             *
+             * @{
+             */
+            [[nodiscard]] constexpr auto begin() const noexcept -> const_iterator { return data(); }
+            [[nodiscard]] constexpr auto cbegin() const noexcept -> const_iterator;
+            [[nodiscard]] constexpr auto end() const noexcept -> const_iterator;
+            [[nodiscard]] constexpr auto cend() const noexcept -> const_iterator;
+            //! @}
+
+            const storage_type value;
+
+        private:
+            template<std::size_t... I>
+            constexpr basic_string_literal(
+                const CharT (&arr)[N + 1],
+                std::index_sequence<I...> /*unused*/) noexcept;
+            template<typename... C>
+            constexpr basic_string_literal(C... c) noexcept;
+    };
+
+    /**
+     * @brief Deduction from string literal.
+     *
+     * @tparam CharT The string character type.
+     * @tparam N     The string literal length.
+     */
+    template<typename CharT, std::size_t N>
+    basic_string_literal(const CharT (&)[N])
+        -> basic_string_literal<std::remove_cv_t<CharT>, N - 1>;
+
+    /**
+     * @brief Convenience aliases for common character types.
+     *
+     * @tparam N The number of characters in the literal.
+     *
+     * @{
+     */
+    template<std::size_t N>
+    using string_literal = basic_string_literal<char, N>;
+    template<std::size_t N>
+    using wstring_literal = basic_string_literal<wchar_t, N>;
+    template<std::size_t N>
+    using u8string_literal = basic_string_literal<char8_t, N>;
+    template<std::size_t N>
+    using u16string_literal = basic_string_literal<char16_t, N>;
+    template<std::size_t N>
+    using u32string_literal = basic_string_literal<char32_t, N>;
+    //! @}
+
+} // namespace mltvrs
+
+#include <mltvrs/ipp/string_literal.ipp>


### PR DESCRIPTION
Introduce `mltvrs::string_literal` to represent compile-time string literals.